### PR TITLE
Make CloudFoundry alert severity configurable

### DIFF
--- a/jobs/cloudfoundry_alerts/spec
+++ b/jobs/cloudfoundry_alerts/spec
@@ -20,48 +20,75 @@ properties:
   cloudfoundry_alerts.app_crashed.evaluation_time:
     description: "Application Crashed alert evaluation time"
     default: 8h
+  cloudfoundry_alerts.app_crashed.severity:
+    description: "Application Crashed alert severity"
+    default: critical
   cloudfoundry_alerts.app_unhealthy.evaluation_time:
     description: "Application Unhealthy alert evaluation time"
     default: 30m
+  cloudfoundry_alerts.app_unhealthy.severity:
+    description: "Application Unhealthy alert severity"
+    default: warning
   cloudfoundry_alerts.cell_unhealthy.evaluation_time:
     description: "Cell Unhealthy alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.cell_unhealthy.severity:
+    description: "Cell Unhealthy alert severity"
+    default: warning
   cloudfoundry_alerts.overall_available_memory.threshold:
     description: "Overall Available Memory (%) alert threshold"
     default: 25
   cloudfoundry_alerts.overall_available_memory.evaluation_time:
     description: "Overall Available Memory alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.overall_available_memory.severity:
+    description: "Overall Available Memory alert severity"
+    default: warning
   cloudfoundry_alerts.max_available_memory.threshold:
     description: "Max Available Memory (MiB) alert threshold"
     default: 4096
   cloudfoundry_alerts.max_available_memory.evaluation_time:
     description: "Max Available Memory alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.max_available_memory.severity:
+    description: "Max Available Memory alert severity"
+    default: warning
   cloudfoundry_alerts.overall_available_disk.threshold:
     description: "Overall Available Disk (%) alert threshold"
     default: 25
   cloudfoundry_alerts.overall_available_disk.evaluation_time:
     description: "Overall Available Disk alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.overall_available_disk.severity:
+    description: "Overall Available Disk alert severity"
+    default: warning
   cloudfoundry_alerts.max_available_disk.threshold:
     description: "Max Available Disk (Mib) alert threshold"
     default: 4096
   cloudfoundry_alerts.max_available_disk.evaluation_time:
     description: "Max Available Disk alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.max_available_disk.severity:
+    description: "Max Available Disk alert severity"
+    default: warning
   cloudfoundry_alerts.overall_available_containers.threshold:
     description: "Overall Available Containers (%) alert threshold"
     default: 25
   cloudfoundry_alerts.overall_available_containers.evaluation_time:
     description: "Overall Available Containers alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.overall_available_containers.severity:
+    description: "Overall Available Containers alert severity"
+    default: warning
   cloudfoundry_alerts.max_available_containers.threshold:
     description: "Max Available Containers alert threshold"
     default: 50
   cloudfoundry_alerts.max_available_containers.evaluation_time:
     description: "Max Available Containers alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.max_available_containers.severity:
+    description: "Max Available Containers alert severity"
+    default: warning
 
   cloudfoundry_alerts.lrp_auctions_failed.threshold:
     description: "LRP Auctions Failed alert threshold"
@@ -69,72 +96,108 @@ properties:
   cloudfoundry_alerts.lrp_auctions_failed.evaluation_time:
     description: "LRP Auctions Failed alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.lrp_auctions_failed.severity:
+    description: "LRP Auctions Failed alert severity"
+    default: warning
   cloudfoundry_alerts.task_auctions_failed.threshold:
     description: "Task Auctions Failed alert threshold"
     default: 1
   cloudfoundry_alerts.task_auctions_failed.evaluation_time:
     description: "Task Auctions Failed alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.task_auctions_failed.severity:
+    description: "Task Auctions Failed alert severity"
+    default: warning
   cloudfoundry_alerts.auctioneer_fetch_states_duration.threshold:
     description: "Auctioneer Fetch States Duration (seconds) alert threshold"
     default: 5
   cloudfoundry_alerts.auctioneer_fetch_states_duration.evaluation_time:
     description: "Auctioneer Fetch States Duration alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.auctioneer_fetch_states_duration.severity:
+    description: "Auctioneer Fetch States Duration alert severity"
+    default: warning
   cloudfoundry_alerts.bbs_convergence_lrp_duration.threshold:
     description: "BBS Convergence LRP Duration (seconds) alert threshold"
     default: 10
   cloudfoundry_alerts.bbs_convergence_lrp_duration.evaluation_time:
     description: "BBS Convergence LRP Duration alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.bbs_convergence_lrp_duration.severity:
+    description: "BBS Convergence LRP Duration alert severity"
+    default: warning
   cloudfoundry_alerts.bbs_request_latency.threshold:
     description: "BBS Request Latency (seconds) alert threshold"
     default: 5
   cloudfoundry_alerts.bbs_request_latency.evaluation_time:
     description: "BBS Request Latency alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.bbs_request_latency.severity:
+    description: "BBS Request Latency alert severity"
+    default: warning
   cloudfoundry_alerts.apps_not_synchronized.evaluation_time:
     description: "Apps Not Synchronized alert evaluation time"
     default: 5m
   cloudfoundry_alerts.tasks_not_synchronized.evaluation_time:
     description: "Tasks Not Synchronized alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.tasks_not_synchronized.severity:
+    description: "Tasks Not Synchronized alert severity"
+    default: warning
   cloudfoundry_alerts.app_instances_fewer_than_expected.threshold:
     description: "App Instances Fewer Than Expected alert threshold"
     default: 5
   cloudfoundry_alerts.app_instances_fewer_than_expected.evaluation_time:
     description: "App Instances Fewer Than Expected alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.app_instances_fewer_than_expected.severity:
+    description: "App Instances Fewer Than Expected alert severity"
+    default: warning
   cloudfoundry_alerts.app_instances_more_than_expected.threshold:
     description: "App Instances More Than Expected alert threshold"
     default: 5
   cloudfoundry_alerts.app_instances_more_than_expected.evaluation_time:
     description: "App Instances More Than Expected alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.app_instances_more_than_expected.severity:
+    description: "App Instances More Than Expected alert severity"
+    default: warning
   cloudfoundry_alerts.rep_bulk_synch_duration.threshold:
     description: "Rep Bulk Synch Duration (seconds) alert threshold"
     default: 10
   cloudfoundry_alerts.rep_bulk_synch_duration.evaluation_time:
     description: "Rep Bulk Synch Duration alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.rep_bulk_synch_duration.severity:
+    description: "Rep Bulk Synch Duration alert severity"
+    default: warning
   cloudfoundry_alerts.nsync_bulker_desired_lrp_sync_duration.threshold:
     description: "BBS Convergence LRP Duration (seconds) alert threshold"
     default: 10
   cloudfoundry_alerts.nsync_bulker_desired_lrp_sync_duration.evaluation_time:
     description: "BBS Convergence LRP Duration alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.nsync_bulker_desired_lrp_sync_duration.severity:
+    description: "BBS Convergence LRP Duration alert severity"
+    default: warning
   cloudfoundry_alerts.grootfs_create_fail.threshold:
     description: "GrootFS create fail alert threshold"
     default: 1
   cloudfoundry_alerts.grootfs_create_fail.evaluation_time:
     description: "GrootFS create fail alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.grootfs_create_fail.severity:
+    description: "GrootFS create fail alert severity"
+    default: warning
   cloudfoundry_alerts.grootfs_delete_fail.threshold:
     description: "GrootFS delete fail alert threshold"
     default: 1
   cloudfoundry_alerts.grootfs_delete_fail.evaluation_time:
     description: "GrootFS delete fail alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.grootfs_delete_fail.severity:
+    description: "GrootFS delete fail alert severity"
+    default: warning
 
   cloudfoundry_alerts.firehose_dropped_messages.threshold:
     description: "Firehose Dropped Messages alert threshold"
@@ -142,10 +205,16 @@ properties:
   cloudfoundry_alerts.firehose_dropped_messages.evaluation_time:
     description: "Firehose Dropped Messages alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.firehose_dropped_messages.severity:
+    description: "Firehose Dropped Messages alert severity"
+    default: warning
 
   cloudfoundry_alerts.etcd_leaders.evaluation_time:
     description: "Etcd More Than One Leader alert evaluation time"
     default: 10m
+  cloudfoundry_alerts.etcd_leaders.severity:
+    description: "Etcd More Than One Leader alert severity"
+    default: critical
 
   cloudfoundry_alerts.router_emitter_sync_duration.threshold:
     description: "Router Emitter Sync Duration (seconds) alert threshold"
@@ -153,48 +222,72 @@ properties:
   cloudfoundry_alerts.router_emitter_sync_duration.evaluation_time:
     description: "Router Emitter Sync Duration alert evaluation time"
     default: 15m
+  cloudfoundry_alerts.router_emitter_sync_duration.severity:
+    description: "Router Emitter Sync Duration alert severity"
+    default: warning
   cloudfoundry_alerts.router_requests.threshold:
     description: "Router Requests alert threshold"
     default: 2500
   cloudfoundry_alerts.router_requests.evaluation_time:
     description: "Router Requests alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.router_requests.severity:
+    description: "Router Requests alert severity"
+    default: warning
   cloudfoundry_alerts.router_requests_drop.threshold:
     description: "Total request rate over past 10 mintues is less thant X% compared to the past 4 hour average, default to 10%"
     default: 10
   cloudfoundry_alerts.router_requests_drop.evaluation_time:
     description: "Router Requests sudden drop alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.router_requests_drop.severity:
+    description: "Router Requests sudden drop alert severity"
+    default: critical
   cloudfoundry_alerts.routers_latency.threshold:
     description: "Routers Latency alert threshold"
     default: 100
   cloudfoundry_alerts.routers_latency.evaluation_time:
     description: "Routers Latency evaluation time"
     default: 30m
+  cloudfoundry_alerts.routers_latency.severity:
+    description: "Routers Latency severity"
+    default: warning
   cloudfoundry_alerts.routes_last_registry.threshold:
     description: "Routes Not Being Registered (seconds) alert threshold"
     default: 30
   cloudfoundry_alerts.routes_last_registry.evaluation_time:
     description: "Routes Not Being Registered alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.routes_last_registry.severity:
+    description: "Routes Not Being Registered alert severity"
+    default: warning
   cloudfoundry_alerts.router_bad_gateway.threshold:
     description: "Router Bad Gateway alert threshold"
     default: 100
   cloudfoundry_alerts.router_bad_gateway.evaluation_time:
     description: "Router Bad Gateway alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.router_bad_gateway.severity:
+    description: "Router Bad Gateway alert severity"
+    default: warning
   cloudfoundry_alerts.router_5xx_responses.threshold:
     description: "Router 5xx Responses alert threshold"
     default: 100
   cloudfoundry_alerts.router_5xx_responses.evaluation_time:
     description: "Router 5xx Responses alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.router_5xx_responses.severity:
+    description: "Router 5xx Responses alert severity"
+    default: warning
   cloudfoundry_alerts.routes_total.threshold:
     description: "Routes Too Low alert threshold"
     default: 5
   cloudfoundry_alerts.routes_total.evaluation_time:
     description: "Routes Too Low alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.routes_total.severity:
+    description: "Routes Too Low alert severity"
+    default: warning
 
   cloudfoundry_alerts.scrape_error.evaluation_time:
     description: "Scrape error alert evaluation time"

--- a/jobs/cloudfoundry_alerts/templates/cf_apps.alerts.yml
+++ b/jobs/cloudfoundry_alerts/templates/cf_apps.alerts.yml
@@ -6,7 +6,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.app_crashed.evaluation_time') %>
         labels:
           service: <%= p('cloudfoundry_alerts.app_service_name') %>
-          severity: critical
+          severity: <%= p('cloudfoundry_alerts.app_crashed.severity') %>
         annotations:
           summary: "CF Application `{{$labels.environment}}/{{$labels.deployment}}/{{$labels.organization_name}}/{{$labels.space_name}}/{{$labels.application_name}}` does not have any instance running"
           description: "CF Application `{{$labels.application_name}}` at environment `{{$labels.environment}}`, deployment `{{$labels.deployment}}`, org `{{$labels.organization_name}}`, and space `{{$labels.space_name}}` has not had any instance running during the last <%= p('cloudfoundry_alerts.app_crashed.evaluation_time') %>"
@@ -16,7 +16,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.app_unhealthy.evaluation_time') %>
         labels:
           service: <%= p('cloudfoundry_alerts.app_service_name') %>
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.app_unhealthy.severity') %>
         annotations:
           summary: "CF Application `{{$labels.environment}}/{{$labels.deployment}}/{{$labels.organization_name}}/{{$labels.space_name}}/{{$labels.application_name}}` is unhealthy"
           description: "CF Application `{{$labels.application_name}}` at environment `{{$labels.environment}}`, deployment `{{$labels.deployment}}`, org `{{$labels.organization_name}}`, and space `{{$labels.space_name}}` had less instances running than desired during the last <%= p('cloudfoundry_alerts.app_unhealthy.evaluation_time') %>"

--- a/jobs/cloudfoundry_alerts/templates/cf_cells.alerts.yml
+++ b/jobs/cloudfoundry_alerts/templates/cf_cells.alerts.yml
@@ -6,7 +6,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.cell_unhealthy.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.cell_unhealthy.severity') %>
         annotations:
           summary: "CF Cell `{{$labels.environment}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_ip}}` is unhealthy"
           description: "CF Cell `{{$labels.environment}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_ip}}` has been unhealthy during the last <%= p('cloudfoundry_alerts.cell_unhealthy.evaluation_time') %>"
@@ -16,7 +16,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.overall_available_memory.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.overall_available_memory.severity') %>
         annotations:
           summary: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` overall available memory too low: {{$value}}%"
           description: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` had less than {{$value}}% of overall available memory during the last <%= p('cloudfoundry_alerts.overall_available_memory.evaluation_time') %>"
@@ -26,7 +26,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.max_available_memory.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.max_available_memory.severity') %>
         annotations:
           summary: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` cell with max available memory is too low: {{$value}}MiB"
           description: "The cell at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` with the maximum available memory has been {{$value}}MiB during the last <%= p('cloudfoundry_alerts.max_available_memory.evaluation_time') %>"
@@ -36,7 +36,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.overall_available_disk.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.overall_available_disk.severity') %>
         annotations:
           summary: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` overall available disk too low: {{$value}}%"
           description: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` had less than {{$value}}% of overall available disk during the last <%= p('cloudfoundry_alerts.overall_available_disk.evaluation_time') %>"
@@ -46,7 +46,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.max_available_disk.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.max_available_disk.severity') %>
         annotations:
           summary: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` cell with max available disk is too low: {{$value}}MiB"
           description: "The cell at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` with the maximum available disk has been {{$value}}MiB during the last <%= p('cloudfoundry_alerts.max_available_disk.evaluation_time') %>"
@@ -56,7 +56,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.overall_available_containers.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.overall_available_containers.severity') %>
         annotations:
           summary: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` overall available containers too low: {{$value}}%"
           description: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` had less than {{$value}}% of overall available containers during the last <%= p('cloudfoundry_alerts.overall_available_containers.evaluation_time') %>"
@@ -66,7 +66,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.max_available_containers.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.max_available_containers.severity') %>
         annotations:
           summary: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` cell with max available containers is too low: {{$value}}"
           description: "The cell at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` with the maximum available containers has been {{$value}} during the last <%= p('cloudfoundry_alerts.max_available_containers.evaluation_time') %>"

--- a/jobs/cloudfoundry_alerts/templates/cf_diego.alerts.yml
+++ b/jobs/cloudfoundry_alerts/templates/cf_diego.alerts.yml
@@ -6,7 +6,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.lrp_auctions_failed.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.lrp_auctions_failed.severity') %>
         annotations:
           summary: "Diego LRP auctions failed at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}}"
           description: "The number of Diego LRP auctions that failed to be placed on cells at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has been too high during the last <%= p('cloudfoundry_alerts.lrp_auctions_failed.evaluation_time') %>"
@@ -16,7 +16,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.task_auctions_failed.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.task_auctions_failed.severity') %>
         annotations:
           summary: "Diego Task auctions failed at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}}"
           description: "The number of Diego Task auctions that failed to be placed on cells at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has been too high during the last <%= p('cloudfoundry_alerts.task_auctions_failed.evaluation_time') %>"
@@ -26,7 +26,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.auctioneer_fetch_states_duration.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.auctioneer_fetch_states_duration.severity') %>
         annotations:
           summary: "Diego Auctioneer fetch state duration at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}} sec"
           description: "Diego Auctioneer at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has been taken {{$value}} seconds to fetch state from Diego Cells for the last <%= p('cloudfoundry_alerts.auctioneer_fetch_states_duration.evaluation_time') %>"
@@ -36,7 +36,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.bbs_convergence_lrp_duration.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.bbs_convergence_lrp_duration.severity') %>
         annotations:
           summary: "Diego BBS Convergence LRP duration at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}} sec"
           description: "Diego BBS at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` had a convergence LRP duration of {{$value}} seconds during the last <%= p('cloudfoundry_alerts.bbs_convergence_lrp_duration.evaluation_time') %>"
@@ -46,7 +46,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.bbs_request_latency.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.bbs_request_latency.severity') %>
         annotations:
           summary: "Diego BBS request latency at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}} sec"
           description: "Diego BBS at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` had a request latency of {{$value}} seconds during the last <%= p('cloudfoundry_alerts.bbs_request_latency.evaluation_time') %>"
@@ -56,7 +56,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.apps_not_synchronized.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.apps_not_synchronized.severity') %>
         annotations:
           summary: "`cf-apps` domain at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is not being kept fresh"
           description: "The `cf-apps` domain at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has not being kept fresh during the last <%= p('cloudfoundry_alerts.apps_not_synchronized.evaluation_time') %>"
@@ -66,7 +66,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.tasks_not_synchronized.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.tasks_not_synchronized.severity') %>
         annotations:
           summary: "`cf-tasks` domain at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is not being kept fresh"
           description: "The `cf-tasks` domain at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has not being kept fresh during the last <%= p('cloudfoundry_alerts.tasks_not_synchronized.evaluation_time') %>"
@@ -76,7 +76,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.app_instances_fewer_than_expected.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.app_instances_fewer_than_expected.severity') %>
         annotations:
           summary: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has {{$value}} fewer app instances than expected"
           description: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has fewer application instances than expected, there has been {{$value}} missing LRPs during the last <%= p('cloudfoundry_alerts.app_instances_fewer_than_expected.evaluation_time') %>"
@@ -86,7 +86,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.app_instances_more_than_expected.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.app_instances_more_than_expected.severity') %>
         annotations:
           summary: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has {{$value}} more app instances than expected"
           description: "CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has more application instances than expected, there has been {{$value}} extra LRPs during the last <%= p('cloudfoundry_alerts.app_instances_more_than_expected.evaluation_time') %>"
@@ -96,7 +96,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.rep_bulk_synch_duration.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.rep_bulk_synch_duration.severity') %>
         annotations:
           summary: "Diego Rep bulk sync duration at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}} sec"
           description: "Diego Rep at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has been taken {{$value}} seconds to sync the ActualLRPs for the last <%= p('cloudfoundry_alerts.rep_bulk_synch_duration.evaluation_time') %>"
@@ -106,7 +106,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.nsync_bulker_desired_lrp_sync_duration.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.nsync_bulker_desired_lrp_sync_duration.severity') %>
         annotations:
           summary: "Diego Nsync bulker desired LRP sync duration at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}} sec"
           description: "Diego Nsync bulker at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` had a desired LRP sync duration of {{$value}} seconds during the last <%= p('cloudfoundry_alerts.nsync_bulker_desired_lrp_sync_duration.evaluation_time') %>"
@@ -116,7 +116,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.grootfs_create_fail.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.grootfs_create_fail.severity') %>
         annotations:
           summary: "GrootFS failed create executions at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}}"
           description: "The number of GrootFS failed create executions at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has been too high during the last <%= p('cloudfoundry_alerts.grootfs_create_fail.evaluation_time') %>"
@@ -126,7 +126,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.grootfs_delete_fail.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.grootfs_delete_fail.severity') %>
         annotations:
           summary: "GrootFS failed delete executions at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}}"
           description: "The number of GrootFS failed delete executions at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has been too high during the last <%= p('cloudfoundry_alerts.grootfs_delete_fail.evaluation_time') %>"

--- a/jobs/cloudfoundry_alerts/templates/cf_doppler.alerts.yml
+++ b/jobs/cloudfoundry_alerts/templates/cf_doppler.alerts.yml
@@ -6,7 +6,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.firehose_dropped_messages.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.firehose_dropped_messages.severity') %>
         annotations:
           summary: "Firehose at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is dropping messages at a high rate: ${{value}} msgs/sec"
           description: "The Firehose at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has been dropping {{$value}} messages per second during the last <%= p('cloudfoundry_alerts.firehose_dropped_messages.evaluation_time') %>"

--- a/jobs/cloudfoundry_alerts/templates/cf_etcd.alerts.yml
+++ b/jobs/cloudfoundry_alerts/templates/cf_etcd.alerts.yml
@@ -6,7 +6,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.etcd_leaders.evaluation_time') %>
         labels:
           service: cf
-          severity: critical
+          severity: <%= p('cloudfoundry_alerts.etcd_leaders.severity') %>
         annotations:
           summary: "`etcd` cluster at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has ${{value}} leaders"
           description: "The `etcd` cluster at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` had {{$value}} leaders during the last <%= p('cloudfoundry_alerts.etcd_leaders.evaluation_time') %>"

--- a/jobs/cloudfoundry_alerts/templates/cf_routers.alerts.yml
+++ b/jobs/cloudfoundry_alerts/templates/cf_routers.alerts.yml
@@ -6,7 +6,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.router_emitter_sync_duration.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.router_emitter_sync_duration.severity') %>
         annotations:
           summary: "Diego Router Emitter synch duration at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}} sec"
           description: "Diego Router Emitter at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` had a synch duration of {{$value}} seconds during the last <%= p('cloudfoundry_alerts.router_emitter_sync_duration.evaluation_time') %>"
@@ -16,7 +16,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.router_requests.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.router_requests.severity') %>
         annotations:
           summary: "Requests per second at CF Router `{{$labels.environment}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_ip}}` is too high: {{$value}}req/s"
           description: "CF Router `{{$labels.environment}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_ip}}` has processed {{$value}} requests per second during the last <%= p('cloudfoundry_alerts.router_requests.evaluation_time') %>"
@@ -28,7 +28,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.router_requests_drop.evaluation_time') %>
         labels:
           service: cf
-          severity: critical
+          severity: <%= p('cloudfoundry_alerts.router_requests_drop.severity') %>
         annotations:
           summary: "Total requests per second have dropped too fast"
           description: "Total requests per second across all routers has dropped below <%= p('cloudfoundry_alerts.router_requests_drop.threshold') %>% during the last <%= p('cloudfoundry_alerts.router_requests_drop.evaluation_time') %>"
@@ -38,7 +38,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.routers_latency.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.routers_latency.severity') %>
         annotations:
           summary: "Router's latency at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}}ms"
           description: "The router's latency at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` has been {{$value}}ms during the last <%= p('cloudfoundry_alerts.routers_latency.evaluation_time') %>"
@@ -48,7 +48,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.routes_last_registry.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.routes_last_registry.severity') %>
         annotations:
           summary: "Routes at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` not being registered"
           description: "Routes at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` are not being registered to apps correctly. It has been at least {{$value}} seconds since a router received a 'router.register' message from an app"
@@ -58,7 +58,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.router_bad_gateway.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.router_bad_gateway.severity') %>
         annotations:
           summary: "Bad gateway responses per second at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}} 5xx res/s"
           description: "Routers at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` have been returning {{$value}} bad gateway responses per second during the last <%= p('cloudfoundry_alerts.router_bad_gateway.evaluation_time') %>"
@@ -68,7 +68,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.router_5xx_responses.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.router_5xx_responses.severity') %>
         annotations:
           summary: "5xx responses per second at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too high: {{$value}} 5xx res/s"
           description: "Routers at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` have been returning {{$value}} 5xx responses per second during the last <%= p('cloudfoundry_alerts.router_5xx_responses.evaluation_time') %>"
@@ -78,7 +78,7 @@ groups:
         for: <%= p('cloudfoundry_alerts.routes_total.evaluation_time') %>
         labels:
           service: cf
-          severity: warning
+          severity: <%= p('cloudfoundry_alerts.routes_total.severity') %>
         annotations:
           summary: "Number of routes at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too low: {{$value}}"
           description: "There has been only {{$value}} routes in the routing table at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` during the last <%= p('cloudfoundry_alerts.routes_total.evaluation_time') %>"


### PR DESCRIPTION
What
---
Make CloudFoundry alert severity configurable
    
Different operators run CloudFoundry in different ways. These alerts are often valuable, but their severity will be different for different operators. Making them configurable recognises that.
    
By default, the configuration is the same as before.

The prometheus-related alerts have been left alone, because they're not related to Cloud Foundry itself.

How to review
---
1. Code review by making sure I extracted the severity levels correctly
2. Run it down your dev env

🚨 Don't merge this. It needs to be made as a PR to the upstream after we review yet 🚨 